### PR TITLE
Hi-C: add .pre format description to README; fix HICCUPS for CPU and 2kb

### DIFF
--- a/Hi-C/README.md
+++ b/Hi-C/README.md
@@ -49,6 +49,25 @@ Hi-C/
 | `<sample>.hic` | Generated from `.pre` with `juicer_tools pre -r <res> -k KR` |
 | `Digest_hg38_*.txt` | MboI restriction digest file for GOTHiC |
 
+#### What is a `.pre` file?
+
+A `.pre` file is the intermediate text format produced by the juicer alignment pipeline. It stores every aligned read pair at base-pair resolution — one pair per line, 11 tab-separated columns:
+
+```
+readname  str1 chr1 pos1 frag1  str2 chr2 pos2 frag2  mapq1 mapq2
+```
+
+| Column | Description |
+|--------|-------------|
+| readname | Read pair ID |
+| str1 / str2 | Strand of each read (0 = forward, 16 = reverse) |
+| chr1 / chr2 | Chromosome of each read |
+| pos1 / pos2 | Genomic position of each read (bp) |
+| frag1 / frag2 | Restriction fragment index |
+| mapq1 / mapq2 | Mapping quality of each read |
+
+Because it stores every read pair as plain text, `.pre` files are large (100+ GB for deep datasets). The `.hic` file is the compressed, binned, indexed form of the same data — smaller and faster to query, but requires the `.pre` to regenerate at a different resolution.
+
 > **Note:** The `.hic` file must have KR normalization at the target resolution.  
 > Generate with: `java -Xmx80g -jar juicer_tools.jar pre -r 2000 -q 30 -k KR -v --threads 18 input.pre output.hic hg38`
 

--- a/Hi-C/hiccups/run_hiccups_HiC.sh
+++ b/Hi-C/hiccups/run_hiccups_HiC.sh
@@ -32,24 +32,27 @@ HIC=$(realpath $HIC)
 mkdir -p $OUTDIR
 
 # Resolution-specific HICCUPS parameters
-# -p peak window (pixels), -i inner distance (pixels)
+# -p peak width (bins), -i window size (bins), -d centroid distance (bp)
+# juicer_tools has no default centroid distance for 2kb — must specify -d explicitly
+# --cpu: CPU-only mode (no GPU required); restricts search to within 8MB of diagonal
 case $RES in
-    2000)  P=2; I=5  ;;
-    5000)  P=4; I=7  ;;
-    10000) P=2; I=5  ;;
-    25000) P=1; I=3  ;;
-    *)     P=2; I=5  ;;
+    2000)  P=2; I=7; D=20000 ;;
+    5000)  P=4; I=7; D=20000 ;;
+    10000) P=2; I=5; D=20000 ;;
+    25000) P=1; I=3; D=25000 ;;
+    *)     P=2; I=7; D=20000 ;;
 esac
 
-echo "[$(date)] Step 1/2 — Running HICCUPS at ${RES}bp..."
+echo "[$(date)] Step 1/2 — Running HICCUPS (CPU) at ${RES}bp (p=$P i=$I d=$D)..."
 java -Xmx80g -jar $JUICER hiccups \
+    --cpu --threads 18 \
     -k KR \
     -r $RES \
     -f 0.1 \
     -p $P \
     -i $I \
+    -d $D \
     -t 0.02,1.5,1.75,2 \
-    --threads 18 \
     $HIC \
     $OUTDIR
 

--- a/Hi-C/run_all_HiC.sh
+++ b/Hi-C/run_all_HiC.sh
@@ -114,14 +114,15 @@ GOTHIC_PID=$!
 # HICCUPS
 (
     case $RES in
-        2000) P=2; I=7  ;;
-        5000) P=4; I=7  ;;
-        *)    P=2; I=5  ;;
+        2000) P=2; I=7; D=20000 ;;
+        5000) P=4; I=7; D=20000 ;;
+        *)    P=2; I=7; D=20000 ;;
     esac
-    echo "[HICCUPS $(date)] Running at ${RES}bp (p=$P i=$I)..."
+    echo "[HICCUPS $(date)] Running at ${RES}bp (p=$P i=$I d=$D)..."
     java -Xmx80g -jar $JUICER hiccups \
-        -k KR -r $RES -f 0.1 -p $P -i $I \
-        -t 0.02,1.5,1.75,2 --threads $THREADS \
+        --cpu --threads $THREADS \
+        -k KR -r $RES -f 0.1 -p $P -i $I -d $D \
+        -t 0.02,1.5,1.75,2 \
         $HIC $WORKDIR/loops/
     POSTPROCESSED=$WORKDIR/loops/postprocessed_pixels_${RES}.bedpe
     if [ -f "$POSTPROCESSED" ]; then


### PR DESCRIPTION
- README: document .pre file format (11-col juicer read pairs)
- hiccups/run_hiccups_HiC.sh: add --cpu flag, -d centroid distance per resolution (required for 2kb — juicer_tools has no 2kb default)
- run_all_HiC.sh: same --cpu and -d fixes in HICCUPS block